### PR TITLE
Add release workflow for PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to publish (e.g. v0.1.0)"
+        type: string
+        required: true
+      publish_pypi:
+        description: "Publish to PyPI (production)"
+        type: boolean
+        default: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - run: python -m pip install build
+      - run: python -m build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/surrox
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_pypi
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/surrox
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: gh release create "$TAG_NAME" dist/* --repo "$GITHUB_REPOSITORY" --generate-notes


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` for automated package publishing
- TestPyPI: publishes automatically on every tag push (`v*`)
- PyPI: publishes via manual workflow_dispatch with `publish_pypi` flag
- GitHub Release: creates release with build artifacts on tag push

## Trusted Publisher Settings

Configure on **PyPI** (https://pypi.org/manage/account/publishing/):

| Field | Value |
|---|---|
| PyPI project name | `surrox` |
| Owner | `kint-pro` |
| Repository | `surrox` |
| Workflow name | `release.yml` |
| Environment name | `pypi` |

Configure on **TestPyPI** (https://test.pypi.org/manage/account/publishing/):

| Field | Value |
|---|---|
| PyPI project name | `surrox` |
| Owner | `kint-pro` |
| Repository | `surrox` |
| Workflow name | `release.yml` |
| Environment name | `testpypi` |

## GitHub Environments

Create two environments in repo Settings > Environments:
1. `pypi` (recommended: add deployment protection rules)
2. `testpypi`

## Usage

**Publish to TestPyPI** (automatic): push a tag
```bash
git tag v0.1.0
git push origin v0.1.0
```

**Publish to PyPI** (manual): go to Actions > Release > Run workflow, check "Publish to PyPI"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)